### PR TITLE
Change Image import to support Pillow

### DIFF
--- a/pyrobot.py
+++ b/pyrobot.py
@@ -318,7 +318,7 @@ class Robot(object):
 			from PIL import Image
 		except ImportError as e:
 			print e
-			print "Need to have PIL installed! See: effbot.org for download"
+			print "Need to have PIL or Pillow installed! See: effbot.org or pypi.python.org for download"
 			sys.exit()
 
 		return self._make_image_from_buffer(self._get_screen_buffer(bounds))


### PR DESCRIPTION
PIL is no longer actively developed, but Pillow is an almost drop-in replacement. It requires only that the Image module be imported from the PIL namespace and not from the global one
