### PR TITLE
_enumerate_windows is now consistent

### DIFF
--- a/pyrobot.py
+++ b/pyrobot.py
@@ -600,6 +600,8 @@ class Robot(object):
 					return
 			titles.append(''.join(title).strip("\x00"))
 
+			return True #Needed to keep looping
+
 		BoolEnumWindowsProc = WINFUNCTYPE(
 			ctypes.c_bool, 
 			ctypes.wintypes.HWND, 


### PR DESCRIPTION
Needed a return True to make the user32.EnumWindows keep looping over windows.

Fixes #9 
