### PR TITLE
A base setup.py file to publish the pyrobot in pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup, find_packages
+
+setup(
+    name="py-robot",
+    version="0.1.0",
+    description="A pure python windows automation library",
+    license="MIT",
+    author="Chris Kiehl",
+    author_email='audionautic@gmail.com',
+    packages=find_packages(),
+    install_requires=[],
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+    ]
+)


### PR DESCRIPTION
Why don't publish the package en pypi? is more easy install with pip

* I create a base setup.py file to publish in pypi. (I get some info from [gooey/setup.py](https://github.com/chriskiehl/Gooey/blob/master/setup.py) )
* In setup.py file, I change the pyrobot name to py-robot because pyrobot is taken.